### PR TITLE
fix failing tests for Python license detector

### DIFF
--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -59,7 +59,7 @@ class LicenseMatcher
 
     top_matches = dists.sort {|a,b| b[1] <=> a[1]}.take(n)
 
-    #translate doc numbers to id
+    # Translate doc numbers to id
     top_matches.reduce([]) do |acc, doc_id_and_score|
       doc_id, score = doc_id_and_score
       acc << [ @model.documents[doc_id].id, score ]

--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -117,13 +117,14 @@ class LicenseMatcher
   #   text - string, a name of license,
   #   early_exit  - boolean, default: true, will only return first match
   # @returns:
+  #   [spdx_id, score, matching_rule]
   def match_rules(text, early_exit = true)
     matches = []
     text_ = text.to_s.strip + " " #required to make difference between end of versionNumber and end of string
     ignore_rules = get_ignore_rules()
 
     #if text is in ignore list, then return same text, but negative score as it's spam
-    return [text_, -1] if matches_any_rule?(ignore_rules, text_)
+    return [text, -1] if matches_any_rule?(ignore_rules, text_)
 
     @rules.each do |spdx_id, rules|
       matching_rule = matches_any_rule?(rules, text_)
@@ -252,7 +253,7 @@ class LicenseMatcher
       /^All\srights\sreserved$/i, /^COPYING$/i, /^OTHER$/i, /^NONE$/i, /^DUAL$/i,
       /^KEEP\s+IT\s+REAL$/i, /\bSee\s+LICENSE\s+file\b/i, /^LICEN[C|S]E$/i,
       /^PUBLIC$/i, /^see file LICENSE$/i, /^__license__$/i,
-      /^GNU$/i, /^GNU[-|\s]?v3$/i, /^OSI\s+Approved$/i, /^OSI$/i,
+      /^GNU\s*$/i, /^GNU[-|\s]?v3$/i, /^OSI\s+Approved$/i, /^OSI$/i,
       /^https?:\/\/github.com/i
     ]
   end

--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -246,14 +246,14 @@ class LicenseMatcher
       /\bDFSG\s+APPROVED\b/i, /\bSee\slicense\sin\spackage\b/i,
       /\bFree\s+for\s+non[-]?commercial\b/i, /\bFree\s+To\s+Use\b/i,
       /\bFree\sFor\sHome\sUse\b/i, /\bFree\s+For\s+Educational\b/i,
-      /^Freely\s+Distributable$/i, /^COPYRIGHT\s+\d{2,4}/i,
-      /^Copyright\s+\(c\)\s+\d{2,4}\b/i, /^COPYRIGHT$/i, /^COPYRIGHT\.\w{2,8}\b/i,
+      /^Freely\s+Distributable\s*$/i, /^COPYRIGHT\s+\d{2,4}/i,
+      /^Copyright\s+\(c\)\s+\d{2,4}\b/i, /^COPYRIGHT\s*$/i, /^COPYRIGHT\.\w{2,8}\b/i,
       /^\(c\)\s+\d{2,4}\d/,
-      /^LICENSE$/i, /^FREE$/i, /^See\sLicense$/i, /^TODO$/i, /^FREEWARE$/i,
-      /^All\srights\sreserved$/i, /^COPYING$/i, /^OTHER$/i, /^NONE$/i, /^DUAL$/i,
-      /^KEEP\s+IT\s+REAL$/i, /\bSee\s+LICENSE\s+file\b/i, /^LICEN[C|S]E$/i,
-      /^PUBLIC$/i, /^see file LICENSE$/i, /^__license__$/i,
-      /^GNU\s*$/i, /^GNU[-|\s]?v3$/i, /^OSI\s+Approved$/i, /^OSI$/i,
+      /^LICENSE\s*$/i, /^FREE\s*$/i, /^See\sLicense\s*$/i, /^TODO\s*$/i, /^FREEWARE\s*$/i,
+      /^All\srights\sreserved\s*$/i, /^COPYING\s*$/i, /^OTHER\s*$/i, /^NONE\s*$/i, /^DUAL\s*$/i,
+      /^KEEP\s+IT\s+REAL\s*$/i, /\bSee\s+LICENSE\s+file\b/i, /^LICEN[C|S]E\s*$/i,
+      /^PUBLIC\s*$/i, /^see file LICENSE\s*$/i, /^__license__\s*$/i,
+      /^GNU\s*$/i, /^GNU[-|\s]?v3\s*$/i, /^OSI\s+Approved\s*$/i, /^OSI\s*$/i,
       /^https?:\/\/github.com/i
     ]
   end

--- a/lib/versioneye/utils/python_license_detector.rb
+++ b/lib/versioneye/utils/python_license_detector.rb
@@ -24,30 +24,32 @@ class PythonLicenseDetector
   end
 
 
-  # Detects all spdx_ids for all the licenses and updates values when askes
-  #  args:
-  #    licenses  - [License], list of License models to work with
-  #    update    - boolean, should it also update License model with detected result
-  #  return:
+  # Detects spdx_ids for the given licenses and updates them in DB.
+  #
+  # args:
+  #    licenses - [License], list of License models to work with
+  #    update   - boolean, should it also update License model with detected result
+  #
+  # return:
   #    Integer - a number of licenses where update
-  def run(licenses, update = false)
-    return if licenses.to_a.empty?
+  #
+  def run( licenses, update = false )
+    return 0 if licenses.to_a.empty?
 
     n, detected, ignored, unknown = [0, 0, 0, 0]
-    licenses.each do |lic|
-      spdx_id, score = detect(lic.name)
-      if spdx_id and score >= 0
-        log.info "PythonLicenseDetector.run: #{lic.to_s} => #{spdx_id}"
-        lic.update(spdx_id: spdx_id) if update == true
+    licenses.each do |license|
+      spdx_id, score = detect( license.name )
+      if spdx_id and score > 0
+        log.info "PythonLicenseDetector.run: #{license.to_s} => #{spdx_id}"
+        license.update(spdx_id: spdx_id) if update == true
         detected += 1
       elsif spdx_id and score < 0
-        #log.info "PythonLicenseDetector.run: ignoring #{lic.to_s}"
+        log.info "PythonLicenseDetector.run: ignoring #{license.to_s} because similarity (#{score}) is too low."
         ignored += 1
       else
-        log.warn "PythonLicenseDetector.run: unknown license for #{lic.to_s} \n #{lic.name}"
+        log.warn "PythonLicenseDetector.run: unknown license for #{license.to_s} \n #{license.name}"
         unknown += 1
       end
-
       n += 1
     end
 
@@ -69,18 +71,7 @@ class PythonLicenseDetector
   #  spdx_id - String | nil, returns a spdx_id of best matching license only if higher than min_confidence
   #
   def detect( license_name )
-    lic_txt = license_name.to_s.downcase.strip
-    return [lic_txt, -1] if lic_txt.size < 3
-
-    rule_ids = @matcher.get_rule_ids
-    results = if rule_ids.has_key?(lic_txt)
-                [[rule_ids[lic_txt], 1.0]] # lic_txt is already an spdx_id
-              elsif lic_txt.size < @min_chars
-                @matcher.match_rules(license_name)
-              else
-                @matcher.match_text(license_name)
-              end
-
+    results = calc_similarities( license_name )
     return [nil, -1] if results.empty?
 
     spdx_id, confidence = results.first
@@ -90,6 +81,21 @@ class PythonLicenseDetector
     end
 
     [spdx_id, -1]
+  end
+
+
+  def calc_similarities( license_name )
+    lic_txt = license_name.to_s.downcase.strip
+    return [lic_txt, -1] if lic_txt.size < 3
+
+    rule_ids = @matcher.get_rule_ids
+    if rule_ids.has_key?(lic_txt)
+      return [[rule_ids[lic_txt], 1.0]] # lic_txt is already an spdx_id
+    elsif lic_txt.size < @min_chars
+      return @matcher.match_rules(license_name)
+    else
+      return @matcher.match_text(license_name)
+    end
   end
 
 

--- a/spec/versioneye/utils/python_license_detector_spec.rb
+++ b/spec/versioneye/utils/python_license_detector_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe PythonLicenseDetector do
-  let(:detector){ PythonLicenseDetector.new }
+  detector = PythonLicenseDetector.new
+
   let(:wtf_text){
     %q[
         DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE


### PR DESCRIPTION
failing tests was caused by broken ignore-rule;