### PR TITLE
refactor LicenseCrawler.crawl_unidentified_urls;

### DIFF
--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -95,6 +95,24 @@ class LicenseMatcher
   def match_url(the_url)
     the_url = the_url.to_s.strip
     spdx_id = nil
+
+    #TODO: if these special cases gets bigger, include into url_index
+    case the_url
+    when 'http://jquery.org/license'
+      return ['MIT', 1.0] #Jquery license page doesnt include any license text
+    when 'https://www.mozilla.org/en-US/MPL/'
+      return ['MPL-2.0', 1.0]
+    when 'http://fairlicense.org'
+      return ['Fair', 1.0]
+    when 'http://www.aforgenet.com/framework/license.html'
+      return ['LGPL-3.0', 1.0]
+    when 'http://aws.amazon.com/apache2.0/'
+      return ['Apache-2.0', 1.0]
+    when 'http://aws.amazon.com/asl/'
+      return ['Amazon', 1.0]
+    end
+
+    #check through SPDX urls
     @url_index.each do |lic_url, lic_id|
       lic_url = lic_url.to_s.strip.gsub(/https?:\/\//i, '').gsub(/www\./, '') #normalizes urls in the file
       matcher = Regexp.new("^https?:\/\/(www\.)?#{lic_url}.*$", Regexp::IGNORECASE)


### PR DESCRIPTION
I made this method more robust and hugely faster:

* checks is the url string even valid URL
* caches URL so when crawler requests the same URL in 2minutes, then it will use cached rules;
* moved some piece of URL matching into `LicenseMatcher.match_url`

NB! I changed function parameters to make it more similar to the PythonLicenseDetector 

Usage:

```
rake console
VersioneyeCore.new
licenses = License.where(language: "CSharp", spdx_id: nil).skip(15 * 1000).limit(1000)
LicenseCrawler.crawl_unidentified_urls licenses #good for experimenting and to enjoy matrix
LicenseCrawler.crawl_unidentified_urls(licenses, 0.9, true) # will update changes
```