### PR TITLE
make PythonLicenseDetector test pass with higher min_confidence level;

### DIFF
--- a/data/custom_licenses/Apache2
+++ b/data/custom_licenses/Apache2
@@ -1,24 +1,12 @@
-Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License"). You
-may not use this file except in compliance with the License. A copy of
-the License is located at
-
-    http://aws.amazon.com/apache2.0/
-
-or in the "license" file accompanying this file. This file is
-distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-ANY KIND, either express or implied. See the License for the specific
-language governing permissions and limitations under the License.
-
 Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
+http://aws.amazon.com/apache2.0/
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/versioneye/utils/python_license_detector.rb
+++ b/lib/versioneye/utils/python_license_detector.rb
@@ -38,7 +38,14 @@ class PythonLicenseDetector
 
     n, detected, ignored, unknown = [0, 0, 0, 0]
     licenses.each do |license|
-      spdx_id, score = detect( license.name_substitute )
+      lic_name = if license.name.length < @min_chars
+                   license.name_substitute
+                else
+                  license.name.strip
+                end
+
+      spdx_id, score = detect( lic_name )
+      
       if spdx_id and score > 0
         log.info "PythonLicenseDetector.run: #{license.to_s[0..100]} => #{spdx_id}"
         if update == true
@@ -84,6 +91,7 @@ class PythonLicenseDetector
       return results.first
     end
 
+    log.warn "PythonLicenseDetector.detect: too low confidence(#{confidence}) for #{spdx_id} : \n#{license_name}"
     [spdx_id, -1]
   end
 


### PR DESCRIPTION
Failing test case was returing lower confidence score that it was defined on the PythonLicenseDetector. I tuned a little bit training file and throw out repeating or extra texts;

I also refactored usage of the `name_substitute` - it's only using this method when the license_name is shorter than `@min_chars`, it's just takes time and resources for long texts;