### PR TITLE
Refactor license crawler

### DIFF
--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -70,7 +70,14 @@ class LicenseMatcher
 
   def match_html(html_doc, n = 3)
     html_doc = safe_encode(html_doc)
-    doc = Nokogiri.HTML(html_doc)
+
+    begin
+      doc = Nokogiri.HTML(html_doc)
+    rescue Exception => e
+      log.error "failed to parse html doc: \n #{html_doc}"
+      doc = nil
+    end
+
     return [] if doc.nil?
 
     body_txt = doc.xpath(

--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -107,11 +107,24 @@ class LicenseMatcher
       return ['Fair', 1.0]
     when 'http://www.aforgenet.com/framework/license.html'
       return ['LGPL-3.0', 1.0]
+    when 'http://www.apache.org/licenses/'
+      return ['Apache-2.0', 1.0]
     when 'http://aws.amazon.com/apache2.0/'
       return ['Apache-2.0', 1.0]
     when 'http://aws.amazon.com/asl/'
       return ['Amazon', 1.0]
+    when 'https://choosealicense.com/no-license/'
+      return ['no-license', 1.0]
+    when 'http://www.gzip.org/zlib/zlib_license.html'
+      return ['zlib', 1.0]
     end
+
+    #does url match with choosealicense.com
+    match = the_url.match /\bhttps?:\/\/(www\.)?choosealicense\.com\/licenses\/([\S|^\/]+)[\/]?\b/i
+    if match
+      return [match[2], 1.0]
+    end
+
 
     #check through SPDX urls
     @url_index.each do |lic_url, lic_id|

--- a/lib/versioneye/utils/license_matcher.rb
+++ b/lib/versioneye/utils/license_matcher.rb
@@ -117,6 +117,8 @@ class LicenseMatcher
       return ['no-license', 1.0]
     when 'http://www.gzip.org/zlib/zlib_license.html'
       return ['zlib', 1.0]
+    when 'http://www.wtfpl.net/about/'
+      return ['wtfpl', 1.0]
     end
 
     #does url match with choosealicense.com
@@ -125,6 +127,10 @@ class LicenseMatcher
       return [match[2], 1.0]
     end
 
+    match = the_url.match /\bhttps?:\/\/(www\.)?creativecommons\.org\/licenses\/([\S|^\/]+)[\/]?\b/i
+    if match
+      return ["cc-#{match[2].to_s.gsub(/\//, '-')}", 1.0]
+    end
 
     #check through SPDX urls
     @url_index.each do |lic_url, lic_id|

--- a/spec/versioneye/utils/license_matcher_spec.rb
+++ b/spec/versioneye/utils/license_matcher_spec.rb
@@ -123,4 +123,11 @@ describe LicenseMatcher do
 		expect( lic_matcher.match_url(gpl3).first ).to eq('GPL-3.0')
 	end
 
+  it "matches chooselicense urls to spdx_Id" do
+    expect(lic_matcher.match_url('https://www.choosealicense.com/licenses/apache-2.0/')[0]).to eq('apache-2.0')
+    expect(lic_matcher.match_url('http://choosealicense.com/licenses/agpl-3.0/')[0]).to eq('agpl-3.0')
+    expect(lic_matcher.match_url('https://choosealicense.com/licenses/cc0-1.0')[0]).to eq('cc0-1.0')
+    expect(lic_matcher.match_url('https://choosealicense.com/licenses/mit/')[0]).to eq('mit')
+  end
+
 end

--- a/spec/versioneye/utils/license_matcher_spec.rb
+++ b/spec/versioneye/utils/license_matcher_spec.rb
@@ -130,4 +130,11 @@ describe LicenseMatcher do
     expect(lic_matcher.match_url('https://choosealicense.com/licenses/mit/')[0]).to eq('mit')
   end
 
+  it "matches cc-commons urls to spdx-id" do
+    expect(lic_matcher.match_url('https://creativecommons.org/licenses/by/4.0')[0]).to eq('cc-by-4.0')
+    expect(lic_matcher.match_url('https://creativecommons.org/licenses/by/4.0/')[0]).to eq('cc-by-4.0')
+    expect(lic_matcher.match_url('https://creativecommons.org/licenses/by-sa/4.0/')[0]).to eq('cc-by-sa-4.0')
+    expect(lic_matcher.match_url('https://creativecommons.org/licenses/by-nc/4.0/')[0]).to eq('cc-by-nc-4.0')
+    expect(lic_matcher.match_url('https://creativecommons.org/licenses/by-nd/4.0/')[0]).to eq('cc-by-nd-4.0')
+  end
 end


### PR DESCRIPTION
changes:

* add support for choosealicense urls
* add support for CommonCopyright urls
* catch HTML parsing error in LicenseMatcher.match_html;