### PR TITLE
make nugetCrawler to save artefacts and sha-values on correct field;

### DIFF
--- a/lib/versioneye/crawlers/nuget_crawler.rb
+++ b/lib/versioneye/crawlers/nuget_crawler.rb
@@ -182,11 +182,11 @@ class NugetCrawler < Versioneye::Crawl
     end
 
     sha_algo = doc[:packageHashAlgorithm].to_s.strip.downcase
+    #nb! Product.version is set by another background worker
     product.update({
       prod_key_dc: doc[:id].to_s.downcase,
       name: doc[:id],
       name_downcase: doc[:id].to_s.downcase,
-      version: doc[:version].to_s.strip, #ps: expect that crawler works from earliest to latest
       description: ( doc[:description] or doc[:summary] ),
       sha256: (sha_algo == 'sha256') ? doc[:packageHash] : nil,
       sha512: (sha_algo == 'sha512') ? doc[:packageHash] : nil,

--- a/spec/versioneye/crawlers/nuget_crawler_spec.rb
+++ b/spec/versioneye/crawlers/nuget_crawler_spec.rb
@@ -31,7 +31,7 @@ describe NugetCrawler do
           "commitTimeStamp":"2015-02-02T06:39:53.9553899Z",
           "count": 1}
         ]
-      }' 
+      }'
   }
   let(:page0_json){
     '{"@id": "https://api.nuget.org/v3/catalog0/page0.json",
@@ -125,7 +125,7 @@ describe NugetCrawler do
         ]
     }'
   }
- 
+
   describe 'is_same_date' do
     it "compares 2 datestring correctly" do
       expect(
@@ -187,6 +187,8 @@ describe NugetCrawler do
 
       expect(License.count).to eq(2)
       expect( Product.count ).to eq(2)
+      expect(Artefact.count).to eq(2)
+
       product = Product.first
 
       expect(product.prod_key).to eq('Adam.JSGenerator')


### PR DESCRIPTION
fix: NugetCrawler saved sha512 into wrong `Product` field
add: updates or inserts Artefact details for each crawled product.