### PR TITLE
Fix nuget crawler issues found from logs.

### DIFF
--- a/lib/versioneye/crawlers/nuget_crawler.rb
+++ b/lib/versioneye/crawlers/nuget_crawler.rb
@@ -8,6 +8,7 @@ class NugetCrawler < Versioneye::Crawl
   A_PROFILE_URL     = "https://www.nuget.org/profiles"
   A_LANGUAGE_CSHARP = Product::A_LANGUAGE_CSHARP
   A_TYPE_NUGET      = Project::A_TYPE_NUGET
+  A_TIMEOUT         = 30 # seconds
 
 
   def self.logger
@@ -46,7 +47,7 @@ class NugetCrawler < Versioneye::Crawl
   # otherwise will only crawl catalogs published on the date_txt
   # date_txt format: YYYY-mm-dd or any other format supported by DateTime.parse
   def self.crawl(date_txt = nil)
-    catalog = self.fetch_json("#{A_NUGET_URL}#{A_CATALOG_PATH}")
+    catalog = self.fetch_json("#{A_NUGET_URL}#{A_CATALOG_PATH}", A_TIMEOUT)
     if catalog.nil?
       self.logger.error "crawl: Failed to fetch the Nuget catalog."
       return nil
@@ -80,7 +81,7 @@ class NugetCrawler < Versioneye::Crawl
 
     self.logger.info "Crawling catalog page: #{the_page[:@id]} - items: #{the_page[:count]}"
 
-    page_items = fetch_json the_page[:@id]
+    page_items = fetch_json( the_page[:@id], A_TIMEOUT )
     if page_items.nil?
       logger.warn "crawl_catalog_page: failed to fetch items on the catalog page: #{the_page}"
       return
@@ -95,7 +96,7 @@ class NugetCrawler < Versioneye::Crawl
       return
     end
 
-    doc = fetch_json the_package[:@id]
+    doc = fetch_json( the_package[:@id], A_TIMEOUT)
     if doc.nil?
       logger.warn "crawl_package: failed to fetch package details from: #{the_package}"
       return
@@ -362,15 +363,31 @@ class NugetCrawler < Versioneye::Crawl
 
 
   def self.upsert_artefact_sha(product, version, sha, sha_method)
-    artefact = Artefact.find_or_create_by(
-                  :language   => product.language,
-                  :prod_key   => product.prod_key,
-                  :version    => version,
-                  :prod_type  => product.prod_type,
-                  :packaging  => 'nupkg',
-                  :sha_value  => sha,
-                  :sha_method => sha_method )
+    artefact = Artefact.where(sha_value: sha).first
+    if artefact and artefact[:prod_key] != product[:prod_key] and artefact[:version] != version
+      logger.error "#-- CRITICAL ERROR ---------------------------------------------------"
+      logger.error "upsert_artefact_sha: sha `#{sha}` belongs to other product #{artefact}"
+      logger.error "\tcurrent_product: #{product} => #{version}, #{sha_method}"
+      return false
+    end
+
+    artefact ||= Artefact.new(
+      :language   => product.language,
+      :prod_key   => product.prod_key,
+      :version    => version,
+      :prod_type  => product.prod_type,
+    )
+
+    artefact.update(
+      packaging: 'nupkg',
+      sha_value: sha,
+      sha_method: sha_method
+    )
     artefact.save
+  rescue => e
+    logger.error "upsert_artefact_sha: failed to save #{product} sha #{sha_method}:#{sha}"
+    logger.error "\treason: #{e.message}"
+    false
   end
 
 

--- a/lib/versioneye/crawlers/nuget_crawler.rb
+++ b/lib/versioneye/crawlers/nuget_crawler.rb
@@ -373,7 +373,7 @@ class NugetCrawler < Versioneye::Crawl
 
   def self.upsert_artefact_sha(product, version, sha, sha_method)
     artefact = Artefact.where(sha_value: sha).first
-    if artefact and artefact[:prod_key] != product[:prod_key] and artefact[:version] != version
+    if artefact and artefact[:prod_key] != product[:prod_key]
       logger.error "#-- CRITICAL ERROR ---------------------------------------------------"
       logger.error "upsert_artefact_sha: sha `#{sha}` belongs to other product #{artefact}"
       logger.error "\tcurrent_product: #{product} => #{version}, #{sha_method}"
@@ -383,15 +383,17 @@ class NugetCrawler < Versioneye::Crawl
     artefact ||= Artefact.new(
       :language   => product.language,
       :prod_key   => product.prod_key,
-      :version    => version,
-      :prod_type  => product.prod_type,
+      :prod_type  => product.prod_type
     )
 
     artefact.update(
+      version: version.to_s.strip,
       packaging: 'nupkg',
       sha_value: sha,
       sha_method: sha_method
     )
+
+
     artefact.save
   rescue => e
     logger.error "upsert_artefact_sha: failed to save #{product} sha #{sha_method}:#{sha}"

--- a/lib/versioneye/crawlers/nuget_crawler.rb
+++ b/lib/versioneye/crawlers/nuget_crawler.rb
@@ -222,6 +222,15 @@ class NugetCrawler < Versioneye::Crawl
       release_dt = parse_date_string( publish_date_label )
     end
 
+    #if package has no release or created date - then use commit Date
+    if release_dt.nil?
+      publish_date_label = product_doc[:'catalog:commitTimeStamp']
+      release_dt = parse_date_string(publish_date_label)
+
+      logger.warn "create_new_version: no `created` or `published` fields\n#{product}\n#{product_doc}"
+      logger.warn "\twill use commitTimeStamp instead - #{publish_date_label}"
+    end
+
     version_db = Version.new({
       version: product_doc[:version],
       released_at: release_dt,


### PR DESCRIPTION
Hi,

this PR fixes couple of issues i found from Nuget's logs:

* **saving duplicate SHA value** - it now will log out conflicting product; but if it is same product, but if only versions are different, then it will update also version - it usually meant that final preview was renamed to full version;

* **request timeouts** - sometimes 5 seconds was just enough, i increased timeout to 30seconds

* **missing release dates** - some packages may have no release or publish date, then it will fallback to a date it was submitted into registry;

